### PR TITLE
FIX: variables no declaradas

### DIFF
--- a/l10n_cl_chart_of_account/models/account_invoice.py
+++ b/l10n_cl_chart_of_account/models/account_invoice.py
@@ -23,6 +23,8 @@ class AccountInvoice(models.Model):
         #@TODO Buscar una mejor forma de aplicar retención
         for inv in self:
             amount_retencion = 0
+            neto = 0
+            amount_tax = 0
             included = False
             for tax in inv.tax_line_ids:
                 if tax.tax_id.price_include:


### PR DESCRIPTION
Este error sale xq las variables no estan declaradas al inicio.
Si hay una factura con impuestos no incluidos, aparece el error