### PR TITLE
[IMP]Opción Desglose de IVA para boletas

### DIFF
--- a/l10n_cl_chart_of_account/__manifest__.py
+++ b/l10n_cl_chart_of_account/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Chile Localization Chart Account SII',
-    'version': '1.4',
+    'version': '1.5',
     'description': """
 Chilean accounting chart and tax localization.
 ==============================================

--- a/l10n_cl_chart_of_account/models/account_tax.py
+++ b/l10n_cl_chart_of_account/models/account_tax.py
@@ -26,6 +26,10 @@ class AccountTaxTemplate(models.Model):
             string="Activo Fijo",
             default=False,
         )
+    sii_detailed = fields.Boolean(
+            string='Desglose de IVA',
+            default=False,
+        )
 
     def _get_tax_vals(self, company, tax_template_to_tax):
         """ This method generates a dictionnary of all the values for the tax that will be created.
@@ -38,6 +42,7 @@ class AccountTaxTemplate(models.Model):
             'retencion': self.retencion,
             'no_rec': self.no_rec,
             'activo_fijo': self.activo_fijo,
+            'sii_detailed': self.sii_detailed,
         })
         return val
 
@@ -65,5 +70,9 @@ class AccountTax(models.Model):
         )
     activo_fijo = fields.Boolean(
             string="Activo Fijo",
+            default=False,
+        )
+    sii_detailed = fields.Boolean(
+            string='Desglose de IVA',
             default=False,
         )

--- a/l10n_cl_chart_of_account/views/account_tax.xml
+++ b/l10n_cl_chart_of_account/views/account_tax.xml
@@ -11,6 +11,7 @@
                 <field name="retencion" attrs="{'required':[('sii_type','in',['R'])], 'invisible':[('sii_type','=',False)]}" />
                 <field name="no_rec" />
                 <field name="activo_fijo" />
+                <field name="sii_detailed" />
             </field>
 
         </field>
@@ -42,6 +43,7 @@
                 <field name="retencion" attrs="{'required':[('sii_type','in',['R'])], 'invisible':[('sii_type','=',False)]}" />
                 <field name="no_rec" />
                 <field name="activo_fijo" />
+                <field name="sii_detailed" />
             </field>
 
         </field>


### PR DESCRIPTION
- Para cuando se configure impuesto + IVA, debe ser opcional si se desglosa o no el IVA en el xml + muestras impresas