### PR TITLE
IMP: crear cuentas para valoracion de inventario

### DIFF
--- a/l10n_cl_chart_of_account/data/l10n_cl_chart_of_account_data.xml
+++ b/l10n_cl_chart_of_account/data/l10n_cl_chart_of_account_data.xml
@@ -203,6 +203,30 @@
             <field name="chart_template_id" ref="cl_chart_template_sii"/>
         </record>
         
+        <record id="110605" model="account.account.template">
+			<field name="name">Cuenta de entrada de stock</field>
+			<field name="code">110605</field>
+			<field name="reconcile" eval="False" />
+			<field ref="account.data_account_type_current_assets" name="user_type_id" />
+			<field name="chart_template_id" ref="cl_chart_template_sii" />
+		</record>
+		
+		<record id="110606" model="account.account.template">
+			<field name="name">Cuenta de salida de stock</field>
+			<field name="code">110606</field>
+			<field name="reconcile" eval="False" />
+			<field ref="account.data_account_type_current_assets" name="user_type_id" />
+			<field name="chart_template_id" ref="cl_chart_template_sii" />
+		</record>
+	
+		<record id="110607" model="account.account.template">
+			<field name="name">Cuenta de valoración de stock</field>
+			<field name="code">110607</field>
+			<field name="reconcile" eval="False" />
+			<field ref="account.data_account_type_current_assets" name="user_type_id" />
+			<field name="chart_template_id" ref="cl_chart_template_sii" />
+		</record>	
+        
         <record id="110701" model="account.account.template">
             <field name="name">IVA Crédito Fiscal</field>
             <field name="code">110701</field>
@@ -1188,5 +1212,8 @@
         <field name="property_account_income_categ_id" ref="410201"/>
         <field name="income_currency_exchange_account_id" ref="620201"/>
         <field name="expense_currency_exchange_account_id" ref="620201"/>
+        <field name="property_stock_account_input_categ_id" ref="110605" />
+		<field name="property_stock_account_output_categ_id" ref="110606" />
+		<field name="property_stock_valuation_account_id" ref="110607" />
     </record>
 </odoo>


### PR DESCRIPTION
Las categorias de productos no vienen configuradas con las cuentas de entrada, salida y variacion de stock.
Este modulo deberia crear esas cuentas y pasarlas por defecto.
Nota: son cambios traidos desde la rama de V12
**Antes:**
![image](https://user-images.githubusercontent.com/7775116/48509769-e6f6f100-e849-11e8-9b50-e4d4c6e14c48.png)


**Despues:**
![image](https://user-images.githubusercontent.com/7775116/48509785-f37b4980-e849-11e8-8613-893d456e9c72.png)


CC @dansanti  @nelsonramirezs 