### PR TITLE
FIX: modulo no debe ser autoinstalable

### DIFF
--- a/l10n_cl_hr/__manifest__.py
+++ b/l10n_cl_hr/__manifest__.py
@@ -43,7 +43,6 @@ Chilean Payroll & Human Resources.
     Report
   """,
     'category': 'Localization/Chile',
-    'active': True,
     'data': [
         'views/hr_indicadores_previsionales_view.xml',
         'views/hr_salary_rule_view.xml',


### PR DESCRIPTION
active se interpreta como auto install, commit original 9fc0b290561457dfdd37c2e690275d921354c622 pero se revertio en commit ca3accb37c0f8430f898389b77f491d251d9addc