### PR TITLE
FIX: cambiar prioridad de reglas salariales

### DIFF
--- a/l10n_cl_hr/data/l10n_cl_hr_payroll_data.xml
+++ b/l10n_cl_hr/data/l10n_cl_hr_payroll_data.xml
@@ -99,7 +99,7 @@ else:
 
         <record id="hr_rule_6" model="hr.salary.rule">
             <field name="name">GRATIFICACION LEGAL</field>
-            <field name="sequence" eval="6"/>
+            <field name="sequence" eval="8"/>
             <field name="code">GRAT</field>
             <field name="category_id" ref="IMPONIBLE"/>
             <field name="condition_select">python</field>
@@ -127,7 +127,7 @@ else:
 
          <record id="hr_rule_8" model="hr.salary.rule">
             <field name="name">COMISIONES</field>
-            <field name="sequence" eval="8"/>
+            <field name="sequence" eval="6"/>
             <field name="code">COMI</field>
             <field name="category_id" ref="IMPONIBLE"/>
             <field name="condition_select">python</field>


### PR DESCRIPTION
la gratificacion depende de todas las reglas que tengan la categroia IMPONIBLE, esas reglas son comisiones y bonos de produccion, pero segun la secuencia se calculan despues de la gratificacion, por ende el valor de la gratificacion no considera ni el bono ni la comision, cambiar la secuencia para que la gratificacion se calcule despues de bono y comisiones