### PR TITLE
ADD: boton para ir a la pagina del PREVIRED

### DIFF
--- a/l10n_cl_hr/views/hr_indicadores_previsionales_view.xml
+++ b/l10n_cl_hr/views/hr_indicadores_previsionales_view.xml
@@ -10,13 +10,20 @@
                     <button string="Update" type="object" name="update_document" context="{'force_update':True}" />
                 </header>
                     <sheet>
+                    	<div class="oe_button_box" name="button_box">
+	                        <a href="https://www.previred.com/web/previred/indicadores-previsionales" class="rounded-circle btn btn-beta" role="button" target="_blank">Ir a Previred</a>
+	                    </div>
                         <div>
-                            <field name="name" invisible="1"/>
-
-                            <group col="4" string="Período"> 
+                        	<group>
+                        		<group string="Período"> 
                                   <field name="month"/>
                                   <field name="year"/>
-                            </group>
+                            	</group>
+                        		<group>
+                        		</group>
+                        	</group>
+                            <field name="name" invisible="1"/>
+
                             <notebook>
                                 <page string="Previred" name="previred">
                                     <table > 


### PR DESCRIPTION
Simplemente agregar un link a la pagina de los indicadores previsionales, idea tomada del modulo de intellego, pero sin agregar un campo, solo se agrega a nivel de vista ya que es solo codigo html

Creditos a @intellego-rbn
![image](https://user-images.githubusercontent.com/7775116/57565043-c1235280-737b-11e9-81a5-8ba5f101cd52.png)
