### PR TITLE
FIX: no mostrar masterdata a usuarios de RRHH, solo a los de nomina

### DIFF
--- a/l10n_cl_hr/views/menu_root.xml
+++ b/l10n_cl_hr/views/menu_root.xml
@@ -15,7 +15,7 @@
 
 	<menuitem id="menu_cl_hr_payroll_master_data"
 		name="Master Data" parent="hr_payroll.menu_hr_payroll_root"
-		sequence="5" />
+		sequence="5" groups="hr_payroll.group_hr_payroll_user" />
 
 	<menuitem id="menu_cl_hr_payroll_reports" name="Reports"
 		parent="hr_payroll.menu_hr_payroll_root" sequence="6"


### PR DESCRIPTION
Antes de este cambio, se estaba mostrando el menu de Master Data a los usuarios de RRHH(sin tener el grupo de Nomina)
Despues de este cambio, se muestra dicho menu solo si el usuario tiene el grupo de nominas. Asi evitamos mostrar datos a los q no debe tener acceso un usuario normal