### PR TITLE
ADD: campo estado en los indicadores previsionales

### DIFF
--- a/l10n_cl_hr/model/hr_indicadores_previsionales.py
+++ b/l10n_cl_hr/model/hr_indicadores_previsionales.py
@@ -15,6 +15,7 @@ MONTH_LIST= [('1', 'Enero'),
         ('10', 'Octubre'), ('11', 'Noviembre'),
         ('12', 'Diciembre')]
 
+STATES = {'draft': [('readonly', False)]}
 
 class hr_indicadores_previsionales(models.Model):
 
@@ -22,121 +23,146 @@ class hr_indicadores_previsionales(models.Model):
     _description = 'Indicadores Previsionales'
 
     name = fields.Char('Nombre')
+    state = fields.Selection([
+        ('draft','Borrador'),
+        ('done','Validado'),
+        ], string=u'Estado', readonly=True, default='draft')
     asignacion_familiar_primer = fields.Float(
         'Asignación Familiar Tramo 1', 
+        readonly=True, states=STATES,
         help="Asig Familiar Primer Tramo")
     asignacion_familiar_segundo = fields.Float(
         'Asignación Familiar Tramo 2', 
+        readonly=True, states=STATES,
         help="Asig Familiar Segundo Tramo")
     asignacion_familiar_tercer = fields.Float(
         'Asignación Familiar Tramo 3', 
+        readonly=True, states=STATES,
         help="Asig Familiar Tercer Tramo")
     asignacion_familiar_monto_a = fields.Float(
-        'Monto Tramo Uno', help="Monto A")
+        'Monto Tramo Uno', readonly=True, states=STATES, help="Monto A")
     asignacion_familiar_monto_b = fields.Float(
-        'Monto Tramo Dos',  help="Monto B")
+        'Monto Tramo Dos', readonly=True, states=STATES, help="Monto B")
     asignacion_familiar_monto_c = fields.Float(
-        'Monto Tramo Tres',  help="Monto C")
+        'Monto Tramo Tres', readonly=True, states=STATES, help="Monto C")
     contrato_plazo_fijo_empleador = fields.Float(
         'Contrato Plazo Fijo Empleador', 
+        readonly=True, states=STATES,
         help="Contrato Plazo Fijo Empleador")
     contrato_plazo_fijo_trabajador = fields.Float(
         'Contrato Plazo Fijo Trabajador', 
+        readonly=True, states=STATES,
         help="Contrato Plazo Fijo Trabajador")    
     contrato_plazo_indefinido_empleador = fields.Float(
         'Contrato Plazo Indefinido Empleador', 
+        readonly=True, states=STATES,
         help="Contrato Plazo Fijo")
     contrato_plazo_indefinido_empleador_otro = fields.Float(
         'Contrato Plazo Indefinido 11 anos o mas', 
+        readonly=True, states=STATES,
         help="Contrato Plazo Indefinido 11 anos Empleador")
     contrato_plazo_indefinido_trabajador_otro = fields.Float(
         'Contrato Plazo Indefinido 11 anos o mas', 
+        readonly=True, states=STATES,
         help="Contrato Plazo Indefinido 11 anos Trabajador")
     contrato_plazo_indefinido_trabajador = fields.Float(
         'Contrato Plazo Indefinido Trabajador', 
+        readonly=True, states=STATES,
         help="Contrato Plazo Indefinido Trabajador")
     caja_compensacion = fields.Float(
         'Caja Compensación', 
+        readonly=True, states=STATES,
         help="Caja de Compensacion")
     deposito_convenido = fields.Float(
-        'Deposito Convenido', help="Deposito Convenido")
-    fonasa = fields.Float('Fonasa',  help="Fonasa")
+        'Deposito Convenido', readonly=True, states=STATES, help="Deposito Convenido")
+    fonasa = fields.Float('Fonasa', readonly=True, states=STATES, help="Fonasa")
     mutual_seguridad = fields.Float(
-        'Mutualidad',  help="Mutual de Seguridad")
+        'Mutualidad', readonly=True, states=STATES, help="Mutual de Seguridad")
     isl = fields.Float(
-        'ISL',  help="Instituto de Seguridad Laboral")
+        'ISL', readonly=True, states=STATES, help="Instituto de Seguridad Laboral")
     pensiones_ips = fields.Float(
-        'Pensiones IPS',  help="Pensiones IPS")
+        'Pensiones IPS', readonly=True, states=STATES, help="Pensiones IPS")
     sueldo_minimo = fields.Float(
-        'Trab. Dependientes e Independientes',  help="Sueldo Minimo")
+        'Trab. Dependientes e Independientes', readonly=True, states=STATES, help="Sueldo Minimo")
     sueldo_minimo_otro = fields.Float(
         'Menores de 18 y Mayores de 65:', 
+        readonly=True, states=STATES,
         help="Sueldo Mínimo para Menores de 18 y Mayores a 65")
     tasa_afp_cuprum = fields.Float(
-        'Cuprum',  help="Tasa AFP Cuprum")
+        'Cuprum', readonly=True, states=STATES, help="Tasa AFP Cuprum")
     tasa_afp_capital = fields.Float(
-        'Capital',  help="Tasa AFP Capital")
+        'Capital', readonly=True, states=STATES, help="Tasa AFP Capital")
     tasa_afp_provida = fields.Float(
-        'ProVida',  help="Tasa AFP Provida")
+        'ProVida', readonly=True, states=STATES, help="Tasa AFP Provida")
     tasa_afp_modelo = fields.Float(
-        'Modelo',  help="Tasa AFP Modelo")
+        'Modelo', readonly=True, states=STATES, help="Tasa AFP Modelo")
     tasa_afp_planvital = fields.Float(
-        'PlanVital',  help="Tasa AFP PlanVital")
+        'PlanVital', readonly=True, states=STATES, help="Tasa AFP PlanVital")
     tasa_afp_habitat = fields.Float(
-        'Habitat',  help="Tasa AFP Habitat")
+        'Habitat', readonly=True, states=STATES, help="Tasa AFP Habitat")
     tasa_sis_cuprum = fields.Float(
-        'SIS', help="Tasa SIS Cuprum")
+        'SIS', readonly=True, states=STATES, help="Tasa SIS Cuprum")
     tasa_sis_capital = fields.Float(
-        'SIS', help="Tasa SIS Capital")
+        'SIS', readonly=True, states=STATES, help="Tasa SIS Capital")
     tasa_sis_provida = fields.Float(
-        'SIS',  help="Tasa SIS Provida")
+        'SIS', readonly=True, states=STATES, help="Tasa SIS Provida")
     tasa_sis_planvital = fields.Float(
-        'SIS',  help="Tasa SIS PlanVital")
+        'SIS', readonly=True, states=STATES, help="Tasa SIS PlanVital")
     tasa_sis_habitat = fields.Float(
-        'SIS',  help="Tasa SIS Habitat")
+        'SIS', readonly=True, states=STATES, help="Tasa SIS Habitat")
     tasa_sis_modelo = fields.Float(
-        'SIS',  help="Tasa SIS Modelo")
+        'SIS', readonly=True, states=STATES, help="Tasa SIS Modelo")
     tasa_independiente_cuprum = fields.Float(
-        'SIS',  help="Tasa Independientes Cuprum")
+        'SIS', readonly=True, states=STATES, help="Tasa Independientes Cuprum")
     tasa_independiente_capital = fields.Float(
-        'SIS',  help="Tasa Independientes Capital")
+        'SIS', readonly=True, states=STATES, help="Tasa Independientes Capital")
     tasa_independiente_provida = fields.Float(
-        'SIS',  help="Tasa Independientes Provida")
+        'SIS', readonly=True, states=STATES, help="Tasa Independientes Provida")
     tasa_independiente_planvital = fields.Float(
-        'SIS',  help="Tasa Independientes PlanVital")
+        'SIS', readonly=True, states=STATES, help="Tasa Independientes PlanVital")
     tasa_independiente_habitat = fields.Float(
-        'SIS',  help="Tasa Independientes Habitat")
+        'SIS', readonly=True, states=STATES, help="Tasa Independientes Habitat")
     tasa_independiente_modelo = fields.Float(
-        'SIS',  help="Tasa Independientes Modelo")
+        'SIS', readonly=True, states=STATES, help="Tasa Independientes Modelo")
     tope_anual_apv = fields.Float(
-        'Tope Anual APV',  help="Tope Anual APV")
+        'Tope Anual APV', readonly=True, states=STATES, help="Tope Anual APV")
     tope_mensual_apv = fields.Float(
-        'Tope Mensual APV',  help="Tope Mensual APV")
+        'Tope Mensual APV', readonly=True, states=STATES, help="Tope Mensual APV")
     tope_imponible_afp = fields.Float(
-        'Tope imponible AFP',  help="Tope Imponible AFP")
+        'Tope imponible AFP', readonly=True, states=STATES, help="Tope Imponible AFP")
     tope_imponible_ips = fields.Float(
-        'Tope Imponible IPS',  help="Tope Imponible IPS")
+        'Tope Imponible IPS', readonly=True, states=STATES, help="Tope Imponible IPS")
     tope_imponible_salud = fields.Float(
-        'Tope Imponible Salud')
+        'Tope Imponible Salud', readonly=True, states=STATES,)
     tope_imponible_seguro_cesantia = fields.Float(
         'Tope Imponible Seguro Cesantía', 
+        readonly=True, states=STATES,
         help="Tope Imponible Seguro de Cesantía")
     uf = fields.Float(
-        'UF',  required=True, help="UF fin de Mes")
+        'UF',  required=True, readonly=True, states=STATES, help="UF fin de Mes")
     utm = fields.Float(
-        'UTM',  required=True, help="UTM Fin de Mes")
-    uta = fields.Float('UTA',  help="UTA Fin de Mes")
+        'UTM',  required=True, readonly=True, states=STATES, help="UTM Fin de Mes")
+    uta = fields.Float('UTA', readonly=True, states=STATES, help="UTA Fin de Mes")
     uf_otros = fields.Float(
-        'UF Otros',  help="UF Seguro Complementario")
-    mutualidad_id = fields.Many2one('hr.mutual', 'MUTUAL')
-    ccaf_id = fields.Many2one('hr.ccaf', 'CCAF')
-    month = fields.Selection(MONTH_LIST, string='Mes', required=True)
-    year = fields.Integer('Año', required=True, default=datetime.now().strftime('%Y'))
-    gratificacion_legal = fields.Boolean('Gratificación L. Manual')
-    mutual_seguridad_bool = fields.Boolean('Mutual Seguridad', default=True)
+        'UF Otros', readonly=True, states=STATES, help="UF Seguro Complementario")
+    mutualidad_id = fields.Many2one('hr.mutual', 'MUTUAL', readonly=True, states=STATES)
+    ccaf_id = fields.Many2one('hr.ccaf', 'CCAF', readonly=True, states=STATES)
+    month = fields.Selection(MONTH_LIST, string='Mes', required=True, readonly=True, states=STATES)
+    year = fields.Integer('Año', required=True, default=datetime.now().strftime('%Y'), readonly=True, states=STATES)
+    gratificacion_legal = fields.Boolean('Gratificación L. Manual', readonly=True, states=STATES)
+    mutual_seguridad_bool = fields.Boolean('Mutual Seguridad', default=True, readonly=True, states=STATES)
     ipc = fields.Float(
-        'IPC',  required=True, help="Indice de Precios al Consumidor (IPC)")
-
+        'IPC',  required=True, readonly=True, states=STATES, help="Indice de Precios al Consumidor (IPC)")
+    
+    @api.multi
+    def action_done(self):
+        self.write({'state': 'done'})
+        return True
+    
+    @api.multi
+    def action_draft(self):
+        self.write({'state': 'draft'})
+        return True
 
     @api.multi
     @api.onchange('month')

--- a/l10n_cl_hr/views/hr_indicadores_previsionales_view.xml
+++ b/l10n_cl_hr/views/hr_indicadores_previsionales_view.xml
@@ -7,8 +7,13 @@
 		<field name="arch" type="xml">
 			<form string="Indicadores Previsionales">
 				<header>
+					<button string="Validar" type="object" name="action_done" states="draft" class="oe_highlight"
+						groups="hr_payroll.group_hr_payroll_user" />
+					<button string="Volver a borrador" type="object" name="action_draft" states="done" 
+						groups="hr_payroll.group_hr_payroll_manager" />
 					<button string="Update" type="object" name="update_document"
-						context="{'force_update':True}" />
+						context="{'force_update':True}" states="draft" />
+					<field name="state" widget="statusbar" />
 				</header>
 				<sheet>
 					<div class="oe_button_box" name="button_box">


### PR DESCRIPTION
la finalidad es evitar que el usuario modifique los datos a su antojo, solo en estado borrador se permitira editar estos datos, se agrego botones para pasar x todo el ciclo del documento(borrador, validado), pero el admin de nominas sera quien puede volver a borrador el documento

ANTES, siempre se puede editar datos:

![image](https://user-images.githubusercontent.com/7775116/58145553-2e56a380-7c18-11e9-96cd-58e419e30199.png)


Despues:

![image](https://user-images.githubusercontent.com/7775116/58145580-44fcfa80-7c18-11e9-8a99-d80eedf11549.png)
