### PR TITLE
FIX: modulo no debe ser autoinstalable

### DIFF
--- a/l10n_cl_hr/__manifest__.py
+++ b/l10n_cl_hr/__manifest__.py
@@ -38,7 +38,6 @@ Chilean Payroll & Human Resources.
     Report
   """,
     'category': 'Localization/Chile',
-    'active': True,
     'data': [
         'views/menu_root.xml',
         'views/hr_indicadores_previsionales_view.xml',

--- a/l10n_cl_hr/data/l10n_cl_hr_indicadores.xml
+++ b/l10n_cl_hr/data/l10n_cl_hr_indicadores.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>						
 <odoo>						
-    <data>						
+    <data noupdate="1">						
 
 
 


### PR DESCRIPTION
active se interpreta como auto_install, esto se habia corregido en el commit 9fc0b290561457dfdd37c2e690275d921354c622 pero se volvio a reintroducir en el commit 56e90415b5c43295533500aa3dd248566a0366ba