### PR TITLE
ADD: campo para configurar si se debe convertir a moneda local 

### DIFF
--- a/sale_order_currency/__manifest__.py
+++ b/sale_order_currency/__manifest__.py
@@ -30,6 +30,7 @@
     'website': 'http://konos.cl',
     'depends': ['base', 'sale', 'account'],
     'data': [
+        'views/sale_order_view.xml',
     ],
     'installable': True,
     'auto_install': False,

--- a/sale_order_currency/models/sale_order.py
+++ b/sale_order_currency/models/sale_order.py
@@ -5,11 +5,14 @@ from odoo.tools.translate import _
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
+    
+    convert_to_company_currency = fields.Boolean(u'Convertir a moneda local?')
 
     @api.multi
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()
-        invoice_vals.update({
-            'currency_id': self.company_id.currency_id.id,
-        })
+        if self.convert_to_company_currency:
+            invoice_vals.update({
+                'currency_id': self.company_id.currency_id.id,
+            })
         return invoice_vals

--- a/sale_order_currency/models/sale_order_line.py
+++ b/sale_order_currency/models/sale_order_line.py
@@ -11,7 +11,7 @@ class SaleOrderLine(models.Model):
     def _prepare_invoice_line(self, qty):
         self.ensure_one()
         res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
-        if self.currency_id and self.company_id and self.currency_id != self.company_id.currency_id:
+        if self.order_id.convert_to_company_currency and self.currency_id and self.company_id and self.currency_id != self.company_id.currency_id:
             company = self.env.user.company_id
             currency = self.order_id.pricelist_id.currency_id
             res.update({

--- a/sale_order_currency/views/sale_order_view.xml
+++ b/sale_order_currency/views/sale_order_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+	<record id="sale_order_form_view" model="ir.ui.view">
+		<field name="name">sale.order.form</field>
+		<field name="model">sale.order</field>
+		<field name="inherit_id" ref="sale.view_order_form" />
+		<field name="arch" type="xml">
+			<field name="payment_term_id" position="after">
+				<field name="convert_to_company_currency"
+					attrs="{'readonly': ['|', ('state','=', 'cancel'), ('invoice_count','!=',0),('state','in',('sale', 'done', 'cancel'))]}"
+					groups="base.group_multi_currency" />
+			</field>
+		</field>
+	</record>
+</odoo>


### PR DESCRIPTION
en el commit 8826ec65818dcd5ae11820bb702b447e0b33ddec se perdio esta configuracion, no siempre se va a convertir a la moneda de la company automaticamente, puede darse el caso que sea necesario facturar en la moneda extranjera(factura de exportacion podria ser un ejemplo)